### PR TITLE
fix warnings from nightly rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "autosar-data",
     "autosar-data-specification",
 ]
+resolver = "2"
 
 [patch.crates-io]
 autosar-data = { path = "autosar-data" }


### PR DESCRIPTION
nightly rust is now complaining about:
 - missing resolver=2 in the workspace
 - invalid_from_utf8 in the utf-8 error case test