### PR TITLE
fix comment handling - xml comments may contain '>'

### DIFF
--- a/autosar-data/src/element.rs
+++ b/autosar-data/src/element.rs
@@ -2021,7 +2021,13 @@ impl Element {
     /// Set or delete the comment attached to the element
     ///
     /// Set None to remove the comment.
-    pub fn set_comment(&self, opt_comment: Option<String>) {
+    pub fn set_comment(&self, mut opt_comment: Option<String>) {
+        if let Some(comment) = &mut opt_comment {
+            // make sure the comment we store never contains "--" as this is forbidden by the w3 xml specification
+            if comment.contains("--") {
+                *comment = comment.replace("--", "__");
+            }
+        }
         self.0.lock().comment = opt_comment;
     }
 

--- a/autosar-data/src/lib.rs
+++ b/autosar-data/src/lib.rs
@@ -94,8 +94,8 @@ mod lexer;
 mod parser;
 
 // allow public access to the error sub-types
-pub use parser::ArxmlParserError;
 pub use lexer::ArxmlLexerError;
+pub use parser::ArxmlParserError;
 
 // reexport some of the info from the specification
 pub use autosar_data_specification::AttributeName;


### PR DESCRIPTION
Additionally, make sure that written comments never contain '--', which would be invalid xml.

fixes issue #15