### PR TITLE
Fix typo in Comments

### DIFF
--- a/autosar-data/src/autosarmodel.rs
+++ b/autosar-data/src/autosarmodel.rs
@@ -608,7 +608,7 @@ impl AutosarModel {
         ArxmlFileIterator::new(self.clone())
     }
 
-    /// Get a referenct to the root ```<AUTOSAR ...>``` element of this model
+    /// Get a reference to the root ```<AUTOSAR ...>``` element of this model
     ///
     /// # Example
     ///

--- a/autosar-data/src/element.rs
+++ b/autosar-data/src/element.rs
@@ -43,11 +43,11 @@ impl Element {
     ///
     /// This function steps through the hierarchy until an identifiable element is found.
     /// It never returns the current element, even if the current element is identifiable.
-    /// 
+    ///
     /// The function returns a suitable element if one is found, or None if the root is reached.
-    /// 
+    ///
     /// # Example
-    /// 
+    ///
     /// ```
     /// # use autosar_data::*;
     /// # fn main() -> Result<(), AutosarDataError> {
@@ -63,9 +63,9 @@ impl Element {
     /// # Ok(())
     /// # }
     /// ```
-    /// 
+    ///
     /// # Possible Errors
-    /// 
+    ///
     ///  - [`AutosarDataError::ItemDeleted`]: The current element is in the deleted state and will be freed once the last reference is dropped
     pub fn named_parent(&self) -> Result<Option<Element>, AutosarDataError> {
         let mut cur_elem_opt = self.parent()?;
@@ -204,7 +204,7 @@ impl Element {
         self.0.read().is_identifiable()
     }
 
-    /// Returns true if the element should contain a referenct to another element
+    /// Returns true if the element should contain a reference to another element
     ///
     /// The function does not check if the reference is valid
     ///

--- a/autosar-data/src/lib.rs
+++ b/autosar-data/src/lib.rs
@@ -364,7 +364,7 @@ pub enum ContentType {
 /// Holds a weak reference to either an element or an arxml file
 ///
 /// This enum is used for references to the parent of each element. For all elements other than the
-/// root element, the parent is an element. The root element itself has a referenct to the `ArxmlFile` structure.
+/// root element, the parent is an element. The root element itself has a reference to the `ArxmlFile` structure.
 #[derive(Clone)]
 pub(crate) enum ElementOrModel {
     Element(WeakElement),


### PR DESCRIPTION
Fixed a small typo in comments. It is also reflected in the documentation.
	modified:   autosar-data/src/autosarmodel.rs
	modified:   autosar-data/src/element.rs
	modified:   autosar-data/src/lib.rs