### PR TITLE
Allow specifying a max depth for elements_dfs

### DIFF
--- a/autosar-data/src/arxmlfile.rs
+++ b/autosar-data/src/arxmlfile.rs
@@ -172,7 +172,31 @@ impl ArxmlFile {
     /// ```
     #[must_use]
     pub fn elements_dfs(&self) -> ArxmlFileElementsDfsIterator {
-        ArxmlFileElementsDfsIterator::new(self)
+        ArxmlFileElementsDfsIterator::new(self, 0)
+    }
+
+    /// Create a depth first iterator over all [Element]s in this file, up to a maximum depth
+    ///
+    /// In a multi-file model it will not return any elements from other files.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use autosar_data::*;
+    /// # let model = AutosarModel::new();
+    /// # let file = model.create_file("test", AutosarVersion::Autosar_00050).unwrap();
+    /// # let element = model.root_element();
+    /// # element.create_sub_element(ElementName::ArPackages).unwrap();
+    /// # let sub_elem = element.get_sub_element(ElementName::ArPackages).unwrap();
+    /// # sub_elem.create_named_sub_element(ElementName::ArPackage, "test2").unwrap();
+    /// for (depth, elem) in file.elements_dfs_with_max_depth(1) {
+    ///     assert!(depth <= 1);
+    ///     // ...
+    /// }
+    /// ```
+    #[must_use]
+    pub fn elements_dfs_with_max_depth(&self, max_depth: usize) -> ArxmlFileElementsDfsIterator {
+        ArxmlFileElementsDfsIterator::new(self, max_depth)
     }
 
     /// Serialize the content of the file to a String
@@ -443,6 +467,40 @@ mod test {
         let file_elem_count_2 = file.elements_dfs().count();
         assert!(proj_elem_count < proj_elem_count_2);
         assert_eq!(file_elem_count, file_elem_count_2);
+    }
+
+    #[test]
+    fn elements_dfs_with_max_depth() {
+        const FILEBUF: &[u8] = r#"<?xml version="1.0" encoding="utf-8"?>
+        <AUTOSAR xsi:schemaLocation="http://autosar.org/schema/r4.0 AUTOSAR_00050.xsd" xmlns="http://autosar.org/schema/r4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <AR-PACKAGES>
+          <AR-PACKAGE><SHORT-NAME>Pkg_A</SHORT-NAME><ELEMENTS>
+            <ECUC-MODULE-CONFIGURATION-VALUES><SHORT-NAME>BswModule</SHORT-NAME><CONTAINERS><ECUC-CONTAINER-VALUE>
+              <SHORT-NAME>BswModuleValues</SHORT-NAME>
+              <PARAMETER-VALUES>
+                <ECUC-NUMERICAL-PARAM-VALUE>
+                  <DEFINITION-REF DEST="ECUC-BOOLEAN-PARAM-DEF">/REF_A</DEFINITION-REF>
+                </ECUC-NUMERICAL-PARAM-VALUE>
+                <ECUC-NUMERICAL-PARAM-VALUE>
+                  <DEFINITION-REF DEST="ECUC-BOOLEAN-PARAM-DEF">/REF_B</DEFINITION-REF>
+                </ECUC-NUMERICAL-PARAM-VALUE>
+                <ECUC-NUMERICAL-PARAM-VALUE>
+                  <DEFINITION-REF DEST="ECUC-BOOLEAN-PARAM-DEF">/REF_C</DEFINITION-REF>
+                </ECUC-NUMERICAL-PARAM-VALUE>
+              </PARAMETER-VALUES>
+            </ECUC-CONTAINER-VALUE></CONTAINERS></ECUC-MODULE-CONFIGURATION-VALUES>
+          </ELEMENTS></AR-PACKAGE>
+          <AR-PACKAGE><SHORT-NAME>Pkg_B</SHORT-NAME></AR-PACKAGE>
+          <AR-PACKAGE><SHORT-NAME>Pkg_C</SHORT-NAME></AR-PACKAGE>
+        </AR-PACKAGES></AUTOSAR>"#.as_bytes();
+        let model = AutosarModel::new();
+        let (file, _) = model.load_buffer(FILEBUF, "test1", true).unwrap();
+        let all_count = file.elements_dfs().count();
+        let lvl2_count = file.elements_dfs_with_max_depth(2).count();
+        assert!(all_count > lvl2_count);
+        for elem in file.elements_dfs_with_max_depth(2) {
+            assert!(elem.0 <= 2);
+        }
     }
 
     #[test]

--- a/autosar-data/src/element.rs
+++ b/autosar-data/src/element.rs
@@ -1402,7 +1402,35 @@ impl Element {
     /// ```
     #[must_use]
     pub fn elements_dfs(&self) -> ElementsDfsIterator {
-        ElementsDfsIterator::new(self)
+        ElementsDfsIterator::new(self, 0)
+    }
+
+    /// Create a depth first iterator over this element and all of its sub elements up to a maximum depth
+    ///
+    /// Each step in the iteration returns the depth and an element. Due to the nature of a depth first search,
+    /// the returned depth can remain the same, increase by one, or decrease by an arbitrary number in each step.
+    ///
+    /// The dfs iterator will always return this element as the first item. A `max_depth` of `0` returns all
+    /// child elements, regardless of depth (like `elements_dfs` does).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use autosar_data::*;
+    /// # let model = AutosarModel::new();
+    /// # let file = model.create_file("test", AutosarVersion::Autosar_00050).unwrap();
+    /// # let element = model.root_element();
+    /// # element.create_sub_element(ElementName::ArPackages).unwrap();
+    /// # let sub_elem = element.get_sub_element(ElementName::ArPackages).unwrap();
+    /// # sub_elem.create_named_sub_element(ElementName::ArPackage, "test2").unwrap();
+    /// for (depth, elem) in element.elements_dfs_with_max_depth(1) {
+    ///     assert!(depth <= 1);
+    ///     // ...
+    /// }
+    /// ```
+    #[must_use]
+    pub fn elements_dfs_with_max_depth(&self, max_depth: usize) -> ElementsDfsIterator {
+        ElementsDfsIterator::new(self, max_depth)
     }
 
     /// Create an iterator over all the attributes in this element
@@ -3964,3 +3992,4 @@ mod test {
         assert!(item6 < item7);
     }
 }
+

--- a/autosar-data/src/iterators.rs
+++ b/autosar-data/src/iterators.rs
@@ -117,9 +117,9 @@ pub struct ArxmlFileElementsDfsIterator {
 }
 
 impl ArxmlFileElementsDfsIterator {
-    pub(crate) fn new(file: &ArxmlFile) -> Self {
+    pub(crate) fn new(file: &ArxmlFile, max_depth: usize) -> Self {
         let weak_file = file.downgrade();
-        let dfs_iter = file.model().ok().map(|m| m.elements_dfs());
+        let dfs_iter = file.model().ok().map(|m| m.elements_dfs_with_max_depth(max_depth));
         Self { weak_file, dfs_iter }
     }
 }

--- a/autosar-data/src/iterators.rs
+++ b/autosar-data/src/iterators.rs
@@ -147,13 +147,15 @@ impl Iterator for ArxmlFileElementsDfsIterator {
 pub struct ElementsDfsIterator {
     elements: Vec<Element>,
     position: Vec<usize>,
+    max_depth: usize,
 }
 
 impl ElementsDfsIterator {
-    pub(crate) fn new(element: &Element) -> Self {
+    pub(crate) fn new(element: &Element, max_depth: usize) -> Self {
         Self {
             elements: vec![element.clone()],
             position: vec![],
+            max_depth,
         }
     }
 
@@ -181,7 +183,8 @@ impl Iterator for ElementsDfsIterator {
                 return Some((depth, element.clone()));
             } else {
                 // return sub elements?
-                if element.content_item_count() > self.position[depth] {
+                let max = self.max_depth;
+                if (max == 0 || max > depth) && element.content_item_count() > self.position[depth] {
                     // more items to show
                     if let Some(e) = element.get_sub_element_at(self.position[depth]) {
                         self.elements.push(e);


### PR DESCRIPTION
This is a backwards-compatible API addition to allow limiting the traversal depth of `elements_dfs` with a new function, `elements_dfs_with_max_depth`.