### PR TITLE
Stop locking dependency versions

### DIFF
--- a/autosar-data/Cargo.toml
+++ b/autosar-data/Cargo.toml
@@ -11,8 +11,8 @@ repository = "https://github.com/DanielT/autosar-data"
 
 [dependencies]
 autosar-data-specification = "0.18"
-thiserror = "~2.0"
-smallvec = { version = "~1.13.0", features = ["union", "const_generics"]}
+thiserror = "2.0"
+smallvec = { version = "1.13.0", features = ["union", "const_generics"]}
 parking_lot = "0.12"
 indexmap = "2.2.0"
 fxhash = "0.2.1"

--- a/autosar-data/src/element.rs
+++ b/autosar-data/src/element.rs
@@ -1969,7 +1969,7 @@ impl Element {
     ///    The operation was aborted to avoid a deadlock, but can be retried.
     ///
     pub fn add_to_file(&self, file: &ArxmlFile) -> Result<(), AutosarDataError> {
-        let parent_splittable = self.parent()?.map_or(true, |p| p.element_type().splittable() != 0);
+        let parent_splittable = self.parent()?.is_none_or(|p| p.element_type().splittable() != 0);
         if parent_splittable {
             if file.model()? == self.model()? {
                 let weak_file = file.downgrade();
@@ -2018,7 +2018,7 @@ impl Element {
             let mut extended_fileset = current_fileset;
             extended_fileset.insert(weak_file);
             // if the parent is splittable, or if the current element already has a fileset, then that fileset should be updated
-            let parent_splittable = self.parent()?.map_or(true, |p| p.element_type().splittable() != 0);
+            let parent_splittable = self.parent()?.is_none_or(|p| p.element_type().splittable() != 0);
             if parent_splittable || local {
                 self.0.write().file_membership = extended_fileset;
             }
@@ -2060,7 +2060,7 @@ impl Element {
     ///    The operation was aborted to avoid a deadlock, but can be retried.
     ///
     pub fn remove_from_file(&self, file: &ArxmlFile) -> Result<(), AutosarDataError> {
-        let parent_splittable = self.parent()?.map_or(true, |p| p.element_type().splittable() != 0);
+        let parent_splittable = self.parent()?.is_none_or(|p| p.element_type().splittable() != 0);
         if parent_splittable {
             if file.model()? == self.model()? {
                 let weak_file = file.downgrade();


### PR DESCRIPTION
Thiserror was locked to 2.0.x and smallvec to 1.13.x. From the history and some testing this doesn't seem to be required, so let's stop to allow updates in downstream dependencies.

This is not yet relevant for thiserror, as it is at 2.0.11, but it is relevant for smallvec which has released 1.14.x.