### PR TITLE
Add support for relative references using reference bases

### DIFF
--- a/autosar-data/src/autosarmodel.rs
+++ b/autosar-data/src/autosarmodel.rs
@@ -1,4 +1,7 @@
-use std::{collections::HashMap, hash::Hash};
+use std::{
+    collections::{HashMap, VecDeque},
+    hash::Hash,
+};
 
 use crate::*;
 
@@ -58,6 +61,8 @@ impl AutosarModel {
             files: Vec::new(),
             identifiables: FxIndexMap::default(),
             reference_origins: FxHashMap::default(),
+            relative_reference_origins: FxHashMap::default(),
+            reference_bases: FxHashMap::default(),
             root_element: root_elem.clone(),
         }
         .wrap();
@@ -189,6 +194,7 @@ impl AutosarModel {
         }
 
         let mut data = self.0.write();
+        // import identifiables from the parser, check for conflicts with existing data
         data.identifiables.reserve(parser.identifiables.len());
         for (key, value) in parser.identifiables {
             // the same identifiables can be present in multiple files
@@ -208,14 +214,38 @@ impl AutosarModel {
                 data.identifiables.insert(key, value);
             }
         }
+
+        // import references from the parser
         data.reference_origins.reserve(parser.references.len());
-        for (refpath, referring_element) in parser.references {
-            if let Some(xref) = data.reference_origins.get_mut(&refpath) {
-                xref.push(referring_element);
+        for (refpath, referring_element, base) in parser.references {
+            if let Some(base_label) = base {
+                //relative reference
+                if let Some(xref) = data.relative_reference_origins.get_mut(&refpath) {
+                    xref.push((referring_element, base_label));
+                } else {
+                    data.relative_reference_origins
+                        .insert(refpath, vec![(referring_element, base_label)]);
+                }
             } else {
-                data.reference_origins.insert(refpath, vec![referring_element]);
+                // absolute reference
+                if let Some(xref) = data.reference_origins.get_mut(&refpath) {
+                    xref.push(referring_element);
+                } else {
+                    data.reference_origins.insert(refpath, vec![referring_element]);
+                }
             }
         }
+
+        // import reference bases from the parser
+        data.reference_bases.reserve(parser.reference_bases.len());
+        for (base_key, base_info) in parser.reference_bases {
+            if let Some(existing_base) = data.reference_bases.get_mut(&base_key) {
+                existing_base.push(base_info);
+            } else {
+                data.reference_bases.insert(base_key, vec![base_info]);
+            }
+        }
+
         data.files.push(arxml_file.clone());
 
         Ok((arxml_file, parser.warnings))
@@ -614,11 +644,12 @@ impl AutosarModel {
                 locked_model.root_element.set_file_membership(HashSet::new());
                 locked_model.identifiables.clear();
                 locked_model.reference_origins.clear();
+                locked_model.relative_reference_origins.clear();
+                locked_model.reference_bases.clear();
             } else {
                 drop(locked_model);
                 // other files still contribute elements, so only the elements specifically associated with this file should be removed
                 let _ = self.root_element().remove_from_file(file);
-                // self.unmerge_file(&file.downgrade());
             }
         }
     }
@@ -931,11 +962,43 @@ impl AutosarModel {
     /// ```
     #[must_use]
     pub fn get_references_to(&self, target_path: &str) -> Vec<WeakElement> {
-        if let Some(origins) = self.0.read().reference_origins.get(target_path) {
+        let locked_model = self.0.read();
+        let mut origins = if let Some(origins) = locked_model.reference_origins.get(target_path) {
             origins.clone()
         } else {
             Vec::new()
+        };
+
+        if !locked_model.relative_reference_origins.is_empty() {
+            // also check for relative references
+            let mut pos = target_path.rfind('/').map(|i| i + 1).unwrap_or(0);
+            while pos > 0 {
+                let suffix = &target_path[pos..];
+                if let Some(rel_origins) = locked_model.relative_reference_origins.get(suffix) {
+                    for (origin, base_label) in rel_origins {
+                        let Some(origin_elem) = origin.upgrade() else {
+                            continue;
+                        };
+                        let Some(package_path) = origin_elem.package().ok().flatten().and_then(|p| p.path().ok())
+                        else {
+                            continue;
+                        };
+                        let Some(base_path) = self.resolve_reference_base(base_label, &package_path) else {
+                            continue;
+                        };
+                        if let Some(rest) = target_path.strip_prefix(&base_path) {
+                            let rest = rest.strip_prefix('/').unwrap_or(rest);
+                            if rest == suffix {
+                                origins.push(origin.clone());
+                            }
+                        }
+                    }
+                }
+                pos = target_path[..pos - 1].rfind('/').map(|i| i + 1).unwrap_or(0);
+            }
         }
+
+        origins
     }
 
     /// check all Autosar path references and return a list of elements with invalid references
@@ -1035,7 +1098,15 @@ impl AutosarModel {
         model.identifiables.swap_remove(path);
     }
 
-    pub(crate) fn add_reference_origin(&self, new_ref: &str, origin: WeakElement) {
+    pub(crate) fn add_reference_origin(&self, new_ref: &str, base: Option<&str>, origin: WeakElement) {
+        if let Some(base) = base {
+            self.add_relative_reference_origin(new_ref, base, origin);
+        } else {
+            self.add_absolute_reference_origin(new_ref, origin);
+        }
+    }
+
+    fn add_absolute_reference_origin(&self, new_ref: &str, origin: WeakElement) {
         let mut data = self.0.write();
         // add the new entry
         if let Some(referrer_list) = data.reference_origins.get_mut(new_ref) {
@@ -1045,30 +1116,39 @@ impl AutosarModel {
         }
     }
 
-    pub(crate) fn fix_reference_origins(&self, old_ref: &str, new_ref: &str, origin: WeakElement) {
-        if old_ref != new_ref {
-            let mut data = self.0.write();
-            let mut remove_list = false;
-            // remove the old entry
-            if let Some(referrer_list) = data.reference_origins.get_mut(old_ref)
-                && let Some(index) = referrer_list.iter().position(|x| *x == origin)
-            {
-                referrer_list.swap_remove(index);
-                remove_list = referrer_list.is_empty();
-            }
-            if remove_list {
-                data.reference_origins.remove(old_ref);
-            }
-            // add the new entry
-            if let Some(referrer_list) = data.reference_origins.get_mut(new_ref) {
-                referrer_list.push(origin);
-            } else {
-                data.reference_origins.insert(new_ref.to_owned(), vec![origin]);
-            }
+    fn add_relative_reference_origin(&self, new_ref: &str, base: &str, origin: WeakElement) {
+        let mut data = self.0.write();
+        if let Some(referrer_list) = data.relative_reference_origins.get_mut(new_ref) {
+            referrer_list.push((origin, base.to_string()));
+        } else {
+            data.relative_reference_origins
+                .insert(new_ref.to_owned(), vec![(origin, base.to_string())]);
         }
     }
 
-    pub(crate) fn remove_reference_origin(&self, reference: &str, element: WeakElement) {
+    pub(crate) fn fix_reference_origins(
+        &self,
+        old_ref: &str,
+        new_ref: &str,
+        old_base: Option<&str>,
+        new_base: Option<&str>,
+        origin: WeakElement,
+    ) {
+        if old_ref != new_ref || old_base != new_base {
+            self.remove_reference_origin(old_ref, old_base, origin.clone());
+            self.add_reference_origin(new_ref, new_base, origin);
+        }
+    }
+
+    pub(crate) fn remove_reference_origin(&self, reference: &str, base: Option<&str>, element: WeakElement) {
+        if let Some(base) = base {
+            self.remove_relative_reference_origin(reference, base, element);
+        } else {
+            self.remove_absolute_reference_origin(reference, element);
+        }
+    }
+
+    fn remove_absolute_reference_origin(&self, reference: &str, element: WeakElement) {
         let mut data = self.0.write();
         let mut count = 1;
         if let Some(referrer_list) = data.reference_origins.get_mut(reference) {
@@ -1079,6 +1159,117 @@ impl AutosarModel {
         }
         if count == 0 {
             data.reference_origins.remove(reference);
+        }
+    }
+
+    fn remove_relative_reference_origin(&self, reference: &str, base: &str, element: WeakElement) {
+        let mut data = self.0.write();
+        let mut count = 1;
+        if let Some(referrer_list) = data.relative_reference_origins.get_mut(reference) {
+            if let Some(index) = referrer_list.iter().position(|(x, b)| *x == element && *b == base) {
+                referrer_list.swap_remove(index);
+            }
+            count = referrer_list.len();
+        }
+        if count == 0 {
+            data.relative_reference_origins.remove(reference);
+        }
+    }
+
+    pub(crate) fn resolve_reference_base(&self, base: &str, ref_package_path: &str) -> Option<String> {
+        let model = self.0.read();
+        let mut current_base = base;
+        let mut path_components = VecDeque::with_capacity(0);
+        let mut ref_package_path = ref_package_path;
+        loop {
+            // get (potentially) a list of reference bases that all have the requested base label
+            let ref_base_info_list = model.reference_bases.get(current_base)?;
+            // select the most applicable reference base from the list based on the owner_package_path (longest prefix match)
+            let ref_base_info = ref_base_info_list
+                .iter()
+                .filter(|info| ref_package_path.starts_with(&info.owner_package_path))
+                .max_by_key(|info| info.owner_package_path.len())?;
+
+            // base is relative to a package, so the path components of the package need to be added to the path
+            if let Some(package_ref_base) = &ref_base_info.package_ref_base {
+                // the reference base uses (at least) another reference base as its own base, so we
+                // loop and build up the path components until we reach a reference base that is absolute
+                path_components.push_front(&ref_base_info.package_ref);
+                current_base = package_ref_base;
+                ref_package_path = &ref_base_info.owner_package_path;
+            } else {
+                if path_components.is_empty() {
+                    return Some(ref_base_info.package_ref.clone());
+                } else {
+                    path_components.push_front(&ref_base_info.package_ref);
+                    // let resolved_path = path_components.join("/"); - join() doesn't exist for &String, so we need to do it manually
+                    let mut resolved_path = String::new();
+                    for component in path_components {
+                        resolved_path.push_str(component);
+                        resolved_path.push('/');
+                    }
+                    resolved_path.pop(); // remove the trailing '/'
+                    return Some(resolved_path);
+                }
+            }
+        }
+    }
+
+    pub(crate) fn fix_reference_base(
+        &self,
+        old_label: Option<String>,
+        new_label: String,
+        package_ref_val: String,
+        ref_base_attr: Option<String>,
+        owner_package_path: String,
+    ) {
+        let mut data = self.0.write();
+        // Remove the previous entry for this owner package under the old label.
+        if let Some(old_label) = old_label {
+            let mut remove_old_key = false;
+            if let Some(ref_base_info_list) = data.reference_bases.get_mut(&old_label) {
+                if let Some(index) = ref_base_info_list
+                    .iter()
+                    .position(|info| info.owner_package_path == owner_package_path)
+                {
+                    ref_base_info_list.swap_remove(index);
+                }
+                remove_old_key = ref_base_info_list.is_empty();
+            }
+            if remove_old_key {
+                data.reference_bases.remove(&old_label);
+            }
+        }
+
+        // Upsert the new entry for this owner package under the new label.
+        let ref_base_info_list = data.reference_bases.entry(new_label).or_default();
+        if let Some(existing_info) = ref_base_info_list
+            .iter_mut()
+            .find(|info| info.owner_package_path == owner_package_path)
+        {
+            existing_info.package_ref = package_ref_val;
+            existing_info.package_ref_base = ref_base_attr;
+        } else {
+            ref_base_info_list.push(ReferenceBaseInfo {
+                package_ref: package_ref_val,
+                package_ref_base: ref_base_attr,
+                owner_package_path,
+            });
+        }
+    }
+
+    /// remove a reference base from the cache
+    pub(crate) fn remove_reference_base(&self, label: &str, owner_package_path: &str) {
+        let mut data = self.0.write();
+        if let Some(ref_base_info_list) = data.reference_bases.get_mut(label)
+            && let Some(index) = ref_base_info_list
+                .iter()
+                .position(|info| info.owner_package_path == owner_package_path)
+        {
+            ref_base_info_list.swap_remove(index);
+            if ref_base_info_list.is_empty() {
+                data.reference_bases.remove(label);
+            }
         }
     }
 }
@@ -1109,6 +1300,8 @@ impl std::fmt::Debug for AutosarModel {
         dbgstruct.field("files", &model.files);
         dbgstruct.field("identifiables", &model.identifiables);
         dbgstruct.field("reference_origins", &model.reference_origins);
+        dbgstruct.field("relative_reference_origins", &model.relative_reference_origins);
+        dbgstruct.field("reference_bases", &model.reference_bases);
         dbgstruct.finish()
     }
 }
@@ -1456,6 +1649,51 @@ mod test {
     }
 
     #[test]
+    fn remove_last_file_clears_relative_reference_origins() {
+        const FILEBUF: &[u8] = r#"<?xml version="1.0" encoding="utf-8"?>
+<AUTOSAR xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://autosar.org/schema/r4.0" xsi:schemaLocation="http://autosar.org/schema/r4.0 AUTOSAR_00050.xsd">
+    <AR-PACKAGES>
+        <AR-PACKAGE>
+            <SHORT-NAME>BasePkg</SHORT-NAME>
+            <ELEMENTS>
+                <ECU-INSTANCE>
+                    <SHORT-NAME>Ecu</SHORT-NAME>
+                </ECU-INSTANCE>
+            </ELEMENTS>
+        </AR-PACKAGE>
+        <AR-PACKAGE>
+            <SHORT-NAME>RefPkg</SHORT-NAME>
+            <REFERENCE-BASES>
+                <REFERENCE-BASE>
+                    <SHORT-LABEL>BaseA</SHORT-LABEL>
+                    <PACKAGE-REF DEST="AR-PACKAGE">/BasePkg</PACKAGE-REF>
+                </REFERENCE-BASE>
+            </REFERENCE-BASES>
+            <ELEMENTS>
+                <SYSTEM>
+                    <SHORT-NAME>Sys</SHORT-NAME>
+                    <FIBEX-ELEMENTS>
+                        <FIBEX-ELEMENT-REF-CONDITIONAL>
+                            <FIBEX-ELEMENT-REF DEST="ECU-INSTANCE" BASE="BaseA">Ecu</FIBEX-ELEMENT-REF>
+                        </FIBEX-ELEMENT-REF-CONDITIONAL>
+                    </FIBEX-ELEMENTS>
+                </SYSTEM>
+            </ELEMENTS>
+        </AR-PACKAGE>
+    </AR-PACKAGES>
+</AUTOSAR>"#
+                        .as_bytes();
+
+        let model = AutosarModel::new();
+        let (file, _) = model.load_buffer(FILEBUF, "test", true).unwrap();
+
+        assert!(!model.0.read().relative_reference_origins.is_empty());
+        model.remove_file(&file);
+
+        assert!(model.0.read().relative_reference_origins.is_empty());
+    }
+
+    #[test]
     fn refcount() {
         let model = AutosarModel::default();
         let weak = model.downgrade();
@@ -1784,7 +2022,6 @@ mod test {
         model2.sort();
         let model2_txt = model2.root_element().serialize();
 
-        println!("{}\n\n=======================\n{}\n\n", model_txt, model2_txt);
         assert_eq!(model_txt, model2_txt);
     }
 
@@ -1844,5 +2081,85 @@ mod test {
         let b1_refs = model.get_references_to("/path/to/entry_B1");
         assert!(b1_refs.len() == 1);
         assert!(b1_refs[0].upgrade().is_some());
+    }
+
+    #[test]
+    fn complex_reference_bases() {
+        const FILEBUF1: &[u8] = r#"<?xml version="1.0" encoding="utf-8"?>
+<AUTOSAR xsi:schemaLocation="http://autosar.org/schema/r4.0 AUTOSAR_00050.xsd" xmlns="http://autosar.org/schema/r4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <AR-PACKAGES>
+    <AR-PACKAGE><SHORT-NAME>BasesPkg</SHORT-NAME>
+      <REFERENCE-BASES>
+        <REFERENCE-BASE>
+          <SHORT-LABEL>BaseA</SHORT-LABEL>
+          <PACKAGE-REF DEST="AR-PACKAGE">/ContentPkg</PACKAGE-REF>
+        </REFERENCE-BASE>
+        <REFERENCE-BASE>
+          <SHORT-LABEL>BaseC</SHORT-LABEL>
+          <PACKAGE-REF DEST="AR-PACKAGE">/ContentPkg2</PACKAGE-REF>
+        </REFERENCE-BASE>
+      </REFERENCE-BASES>
+      <AR-PACKAGES>
+        <AR-PACKAGE><SHORT-NAME>SubPackage</SHORT-NAME>
+          <REFERENCE-BASES>
+            <REFERENCE-BASE>
+              <SHORT-LABEL>BaseB</SHORT-LABEL>
+              <PACKAGE-REF DEST="AR-PACKAGE" BASE="BaseA">SubPackage</PACKAGE-REF>
+            </REFERENCE-BASE>
+          </REFERENCE-BASES>
+          <ELEMENTS>
+            <SYSTEM><SHORT-NAME>System</SHORT-NAME>
+              <FIBEX-ELEMENTS>
+                <FIBEX-ELEMENT-REF-CONDITIONAL>
+                  <FIBEX-ELEMENT-REF DEST="ECU-INSTANCE" BASE="BaseB">Ecu</FIBEX-ELEMENT-REF>
+                </FIBEX-ELEMENT-REF-CONDITIONAL>
+                <FIBEX-ELEMENT-REF-CONDITIONAL>
+                  <FIBEX-ELEMENT-REF DEST="ECU-INSTANCE" BASE="BaseC">Ecu</FIBEX-ELEMENT-REF>
+                </FIBEX-ELEMENT-REF-CONDITIONAL>
+              </FIBEX-ELEMENTS>
+            </SYSTEM>
+          </ELEMENTS>
+        </AR-PACKAGE>
+      </AR-PACKAGES>
+    </AR-PACKAGE>
+    <AR-PACKAGE><SHORT-NAME>ContentPkg</SHORT-NAME>
+      <AR-PACKAGES>
+        <AR-PACKAGE><SHORT-NAME>SubPackage</SHORT-NAME>
+          <ELEMENTS>
+            <ECU-INSTANCE><SHORT-NAME>Ecu</SHORT-NAME></ECU-INSTANCE>
+          </ELEMENTS>
+        </AR-PACKAGE>
+      </AR-PACKAGES>
+    </AR-PACKAGE>
+    <AR-PACKAGE><SHORT-NAME>ContentPkg2</SHORT-NAME>
+      <ELEMENTS>
+        <ECU-INSTANCE><SHORT-NAME>Ecu</SHORT-NAME></ECU-INSTANCE>
+      </ELEMENTS>
+    </AR-PACKAGE>
+  </AR-PACKAGES>
+</AUTOSAR>"#.as_bytes();
+        let model = AutosarModel::new();
+        let result = model.load_buffer(FILEBUF1, "test", true);
+        assert!(result.is_ok());
+
+        let el_system = model.get_element_by_path("/BasesPkg/SubPackage/System").unwrap();
+        let el_fibex_elements = el_system.get_sub_element(ElementName::FibexElements).unwrap();
+        let el_fibex_element_ref = el_fibex_elements
+            .get_sub_element_at(0)
+            .and_then(|ferc| ferc.get_sub_element(ElementName::FibexElementRef))
+            .unwrap();
+
+        // check that we can resolve the reference across multiple levels of reference bases
+        let el_ecu = el_fibex_element_ref.get_reference_target().unwrap();
+        assert_eq!(el_ecu.element_name(), ElementName::EcuInstance);
+
+        // check that the reference origins are correct
+        let origins = model.get_references_to(&el_ecu.path().unwrap());
+        assert_eq!(origins.len(), 1);
+        let origin = origins[0].upgrade().unwrap();
+        assert_eq!(origin.element_name(), ElementName::FibexElementRef);
+
+        let origins2 = model.get_references_to("/ContentPkg2/Ecu");
+        assert_eq!(origins2.len(), 1);
     }
 }

--- a/autosar-data/src/element.rs
+++ b/autosar-data/src/element.rs
@@ -244,6 +244,60 @@ impl Element {
         self.0.read().path()
     }
 
+    /// Get the package element containing the current element
+    ///
+    /// It never returns the current element, even if the current element is a package, but always
+    /// goes up the hierarchy to find the nearest parent package.
+    ///
+    /// Returns
+    ///   Ok(Some(Element)) if a parent package is found
+    ///   Ok(None) at the top level.
+    ///   Err if the action cannot be completed
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use autosar_data::*;
+    /// # fn main() -> Result<(), AutosarDataError> {
+    /// # let model = AutosarModel::new();
+    /// # let file = model.create_file("test", AutosarVersion::Autosar_00050).unwrap();
+    /// # let element = model.root_element().create_sub_element(ElementName::ArPackages)?.create_named_sub_element(ElementName::ArPackage, "Pkg")?;
+    /// let package = element.package()?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// - [`AutosarDataError::ItemDeleted`]: The current element is in the deleted state and will be freed once the last reference is dropped
+    /// - [`AutosarDataError::ParentElementLocked`]: a parent element was locked and did not become available after waiting briefly.
+    ///   The operation was aborted to avoid a deadlock, but can be retried.
+    pub fn package(&self) -> Result<Option<Element>, AutosarDataError> {
+        let mut cur_elem = self.clone();
+        loop {
+            let parent = {
+                let element = cur_elem
+                    .0
+                    .try_read_for(std::time::Duration::from_millis(10))
+                    .ok_or(AutosarDataError::ParentElementLocked)?;
+                match &element.parent {
+                    ElementOrModel::Element(weak_parent) => {
+                        let parent = weak_parent.upgrade().ok_or(AutosarDataError::ItemDeleted)?;
+                        if parent.element_name() == ElementName::ArPackage {
+                            return Ok(Some(parent));
+                        }
+                        parent
+                    }
+                    ElementOrModel::Model(_) => {
+                        return Ok(None);
+                    }
+                    ElementOrModel::None => return Err(AutosarDataError::ItemDeleted),
+                }
+            };
+            cur_elem = parent;
+        }
+    }
+
     /// Get a reference to the [`AutosarModel`] containing the current element
     ///
     /// # Example
@@ -792,41 +846,130 @@ impl Element {
     ///  - [`AutosarDataError::ElementNotIdentifiable`]: The target element is not identifiable, so it cannot be referenced by an Autosar path
     ///  - [`AutosarDataError::NoFilesInModel`]: The operation cannot be completed because the model does not contain any files
     pub fn set_reference_target(&self, target: &Element) -> Result<(), AutosarDataError> {
+        self.set_reference_target_internal(target, None)
+    }
+
+    /// Set the reference target using a relative path and explicit BASE label
+    ///
+    /// This method behaves like [`Self::set_reference_target`], but it writes
+    /// a relative reference path and sets the BASE attribute to `base_label`.
+    ///
+    /// # Errors
+    ///
+    ///  - [`AutosarDataError::ItemDeleted`]: The current element is in the deleted state and will be freed once the last reference is dropped
+    ///  - [`AutosarDataError::ParentElementLocked`]: a parent element was locked and did not become available after waiting briefly.
+    ///    The operation was aborted to avoid a deadlock, but can be retried.
+    ///  - [`AutosarDataError::NotReferenceElement`]: The current element is not a reference, so it is not possible to set a reference target
+    ///  - [`AutosarDataError::InvalidReference`]: The target element is not a valid reference target for this reference
+    ///  - [`AutosarDataError::InvalidReferenceBase`]: The target element uses an invalid base label
+    ///  - [`AutosarDataError::ElementNotIdentifiable`]: The target element is not identifiable, so it cannot be referenced by an Autosar path
+    ///  - [`AutosarDataError::NoFilesInModel`]: The operation cannot be completed because the model does not contain any files
+    pub fn set_relative_reference_target(&self, target: &Element, base_label: &str) -> Result<(), AutosarDataError> {
+        self.set_reference_target_internal(target, Some(base_label))
+    }
+
+    fn set_reference_target_internal(
+        &self,
+        target: &Element,
+        base_label: Option<&str>,
+    ) -> Result<(), AutosarDataError> {
         // the current element must be a reference
-        if self.is_reference() {
-            // the target element must be identifiable, i.e. it has an autosar path
-            let new_ref = target.path()?;
-            // it must be possible to use the name of the referenced element name as an enum item in the dest attribute of the reference
-            if let Some(enum_item) = EnumItem::from_str(target.element_name().to_str())
-                .ok()
-                .or(self.element_type().reference_dest_value(&target.element_type()))
-            {
-                let model = self.model()?;
-                let version = self.min_version()?;
-                let mut element = self.0.write();
-                // set the DEST attribute first - this could fail if the target element has the wrong type
-                if element
-                    .set_attribute_internal(AttributeName::Dest, CharacterData::Enum(enum_item), version)
-                    .is_ok()
-                {
-                    // if this reference previously referenced some other element, update
-                    if let Some(CharacterData::String(old_ref)) = element.character_data() {
-                        model.fix_reference_origins(&old_ref, &new_ref, self.downgrade());
-                    } else {
-                        // else initialise the new reference
-                        model.add_reference_origin(&new_ref, self.downgrade());
-                    }
-                    element.set_character_data(CharacterData::String(new_ref), version)?;
-                    Ok(())
-                } else {
-                    Err(AutosarDataError::InvalidReference)
-                }
-            } else {
-                Err(AutosarDataError::InvalidReference)
-            }
-        } else {
-            Err(AutosarDataError::NotReferenceElement)
+        if !self.is_reference() {
+            return Err(AutosarDataError::NotReferenceElement);
         }
+
+        // the target element must be identifiable, i.e. it has an autosar path
+        let new_ref = target.path()?;
+        // it must be possible to use the name of the referenced element name as an enum item in the dest attribute of the reference
+        let Some(enum_item) = EnumItem::from_str(target.element_name().to_str())
+            .ok()
+            .or(self.element_type().reference_dest_value(&target.element_type()))
+        else {
+            return Err(AutosarDataError::InvalidReference);
+        };
+
+        let model = self.model()?;
+        // build a target string, which is either the absolute path or the relative path depending on whether a base label was provided
+        let target_string = if let Some(base_label) = base_label {
+            // note - a reference can never occur outside a package, so we can unwrap Some(package) here without risking a panic
+            let ref_package_path = self.package()?.unwrap().path()?;
+            let base_path = model
+                .resolve_reference_base(base_label, &ref_package_path)
+                .ok_or(AutosarDataError::InvalidReferenceBase)?;
+            let mut trimmed_target_path = new_ref
+                .strip_prefix(&base_path)
+                .ok_or(AutosarDataError::InvalidReferenceBase)?;
+            if let Some(no_leading_slash) = trimmed_target_path.strip_prefix('/') {
+                trimmed_target_path = no_leading_slash;
+            }
+            trimmed_target_path.to_string()
+        } else {
+            new_ref
+        };
+
+        let version = self.min_version()?;
+        let mut element = self.0.write();
+        // set the DEST attribute first - this could fail if the target element has the wrong type
+        if element
+            .set_attribute_internal(AttributeName::Dest, CharacterData::Enum(enum_item), version)
+            .is_err()
+        {
+            return Err(AutosarDataError::InvalidReference);
+        }
+
+        let opt_old_ref = element.character_data().and_then(|cdata| cdata.string_value());
+
+        // if this reference previously referenced some other element, update
+        if let Some(old_ref) = opt_old_ref {
+            let old_base = element
+                .attribute_value(AttributeName::Base)
+                .and_then(|cdata| cdata.string_value());
+            model.fix_reference_origins(
+                &old_ref,
+                &target_string,
+                old_base.as_deref(),
+                base_label,
+                self.downgrade(),
+            );
+        } else {
+            // else initialise the new reference
+            model.add_reference_origin(&target_string, base_label, self.downgrade());
+        }
+
+        // if this is the PackageRef of a ReferenceBase, then we need to update the ReferenceBase index in the model
+        if element.element_name() == ElementName::PackageRef
+            && let Ok(Some(parent)) = element.parent()
+            && parent.element_name() == ElementName::ReferenceBase
+            && let Some(label) = parent
+                .get_sub_element(ElementName::ShortLabel)
+                .and_then(|e| e.character_data())
+                .and_then(|c| c.string_value())
+            && let Ok(Some(package)) = parent.package()
+            && let Ok(owner_package_path) = package.path()
+        {
+            model.fix_reference_base(
+                Some(label.clone()),
+                label,
+                target_string.clone(),
+                base_label.map(|s| s.to_string()),
+                owner_package_path,
+            );
+        }
+
+        // do the update
+        element.set_character_data(CharacterData::String(target_string), version)?;
+        if let Some(base_label) = base_label {
+            element.set_attribute_internal(
+                AttributeName::Base,
+                CharacterData::String(base_label.to_string()),
+                version,
+            )?;
+        } else {
+            // ensure BASE does not remain when retargeting from a relative reference to an absolute reference
+            element.remove_attribute(AttributeName::Base);
+        }
+
+        Ok(())
     }
 
     /// Get the referenced element
@@ -871,8 +1014,22 @@ impl Element {
         if self.is_reference() {
             if let Some(CharacterData::String(reference)) = self.character_data() {
                 let model = self.model()?;
+
+                let full_path = if let Some(base_label) = self
+                    .attribute_value(AttributeName::Base)
+                    .and_then(|cdata| cdata.string_value())
+                {
+                    // note - a reference can never occur outside a package, so we can unwrap Some(package) here without risking a panic
+                    let ref_package_path = self.package()?.unwrap().path()?;
+                    let reference_base = model
+                        .resolve_reference_base(&base_label, &ref_package_path)
+                        .ok_or(AutosarDataError::InvalidReference)?;
+                    format!("{reference_base}/{reference}")
+                } else {
+                    reference
+                };
                 let target_elem = model
-                    .get_element_by_path(&reference)
+                    .get_element_by_path(&full_path)
                     .ok_or(AutosarDataError::InvalidReference)?;
 
                 let dest_value = self
@@ -960,6 +1117,12 @@ impl Element {
                     None
                 };
 
+                let old_label = if self.element_name() == ElementName::ShortLabel {
+                    self.character_data().and_then(|cdata| cdata.string_value())
+                } else {
+                    None
+                };
+
                 // update the character data
                 {
                     let mut element = self.0.write();
@@ -979,10 +1142,37 @@ impl Element {
                 if elemtype.is_ref()
                     && let Some(CharacterData::String(refval)) = self.character_data()
                 {
+                    let base = self
+                        .attribute_value(AttributeName::Base)
+                        .and_then(|cdata| cdata.string_value());
                     if let Some(old_refval) = old_refval {
-                        model.fix_reference_origins(&old_refval, &refval, self.downgrade());
+                        model.fix_reference_origins(
+                            &old_refval,
+                            &refval,
+                            base.as_deref(),
+                            base.as_deref(),
+                            self.downgrade(),
+                        );
                     } else {
-                        model.add_reference_origin(&refval, self.downgrade());
+                        model.add_reference_origin(&refval, base.as_deref(), self.downgrade());
+                    }
+                } else if self.element_name() == ElementName::ShortLabel
+                    && let Ok(Some(parent)) = self.parent()
+                    && parent.element_name() == ElementName::ReferenceBase
+                    && let Ok(Some(package)) = parent.package()
+                    && let Ok(owner_package_path) = package.path()
+                {
+                    // setting or updating the label of a ReferenceBase
+                    if let Some(package_ref) = parent.get_sub_element(ElementName::PackageRef)
+                        && let Some(package_ref_val) =
+                            package_ref.character_data().and_then(|cdata| cdata.string_value())
+                    {
+                        let base_attr = package_ref
+                            .attribute_value(AttributeName::Base)
+                            .and_then(|cdata| cdata.string_value());
+                        // obviously the new label exists since we just set it
+                        let new_label = self.character_data().and_then(|cdata| cdata.string_value()).unwrap();
+                        model.fix_reference_base(old_label, new_label, package_ref_val, base_attr, owner_package_path);
                     }
                 }
 
@@ -1033,7 +1223,10 @@ impl Element {
                     if self.is_reference() {
                         let model = self.model()?;
                         if let Some(CharacterData::String(reference)) = self.character_data() {
-                            model.remove_reference_origin(&reference, self.downgrade());
+                            let base = self
+                                .attribute_value(AttributeName::Base)
+                                .and_then(|cdata| cdata.string_value());
+                            model.remove_reference_origin(&reference, base.as_deref(), self.downgrade());
                         }
                     }
                     self.0.write().content.clear();
@@ -1538,7 +1731,13 @@ impl Element {
         value: T,
     ) -> Result<(), AutosarDataError> {
         let version = self.min_version()?;
-        self.0.write().set_attribute_internal(attrname, value.into(), version)
+        let (old_base, reference_value) = self.base_attribute_info(attrname);
+
+        self.0.write().set_attribute_internal(attrname, value.into(), version)?;
+
+        self.base_attribute_fixup(attrname, old_base, reference_value);
+
+        Ok(())
     }
 
     /// Set the value of a named attribute from a string
@@ -1564,7 +1763,14 @@ impl Element {
     ///  - [`AutosarDataError::NoFilesInModel`]: The operation cannot be completed because the model does not contain any files
     pub fn set_attribute_string(&self, attrname: AttributeName, stringvalue: &str) -> Result<(), AutosarDataError> {
         let version = self.min_version()?;
-        self.0.write().set_attribute_string(attrname, stringvalue, version)
+        let (old_base, reference_value) = self.base_attribute_info(attrname);
+
+        self.0.write().set_attribute_string(attrname, stringvalue, version)?;
+
+        // post-change fixup for BASE attribute changes only
+        self.base_attribute_fixup(attrname, old_base, reference_value);
+
+        Ok(())
     }
 
     /// Remove an attribute from the element
@@ -1583,7 +1789,46 @@ impl Element {
     /// ```
     #[must_use]
     pub fn remove_attribute(&self, attrname: AttributeName) -> bool {
-        self.0.write().remove_attribute(attrname)
+        let (old_base, reference_value) = self.base_attribute_info(attrname);
+
+        let removed = self.0.write().remove_attribute(attrname);
+
+        if removed {
+            // fix the cache of reference origins if a BASE attribute was removed
+            self.base_attribute_fixup(attrname, old_base, reference_value);
+        }
+        removed
+    }
+
+    /// helper function to get the old BASE attribute value and the reference value before changing or removing the attribute
+    fn base_attribute_info(&self, attrname: AttributeName) -> (Option<String>, Option<String>) {
+        if !self.is_reference() || attrname != AttributeName::Base {
+            return (None, None);
+        }
+        let old_base = self
+            .attribute_value(AttributeName::Base)
+            .and_then(|cdata| cdata.string_value());
+        let reference_value = self.character_data().and_then(|cdata| cdata.string_value());
+        (old_base, reference_value)
+    }
+
+    /// fix the reference origins of a reference element if the BASE attribute was changed or removed
+    fn base_attribute_fixup(&self, attrname: AttributeName, old_base: Option<String>, reference_value: Option<String>) {
+        if attrname == AttributeName::Base
+            && let Some(reference_value) = reference_value
+            && let Ok(model) = self.model()
+        {
+            let new_base = self
+                .attribute_value(AttributeName::Base)
+                .and_then(|cdata| cdata.string_value());
+            model.fix_reference_origins(
+                &reference_value,
+                &reference_value,
+                old_base.as_deref(),
+                new_base.as_deref(),
+                self.downgrade(),
+            );
+        }
     }
 
     /// Recursively sort all sub-elements of this element
@@ -2701,6 +2946,29 @@ mod test {
     }
 
     #[test]
+    fn package() {
+        let model = AutosarModel::new();
+        model.create_file("test.arxml", AutosarVersion::Autosar_00050).unwrap();
+        let el_autosar = model.root_element();
+        let el_ar_packages = el_autosar.create_sub_element(ElementName::ArPackages).unwrap();
+        let el_ar_package = el_ar_packages
+            .create_named_sub_element(ElementName::ArPackage, "Package")
+            .unwrap();
+        let el_ar_packages_2 = el_ar_package.create_sub_element(ElementName::ArPackages).unwrap();
+        let el_ar_package_2 = el_ar_packages_2
+            .create_named_sub_element(ElementName::ArPackage, "SubPackage")
+            .unwrap();
+
+        assert_eq!(el_ar_package.package().unwrap(), None); // top level package has no parent package
+        assert_eq!(el_ar_packages_2.package().unwrap().unwrap(), el_ar_package);
+        assert_eq!(el_ar_package_2.package().unwrap().unwrap(), el_ar_package); // SubPackage -> Package
+
+        drop(el_autosar);
+        drop(model);
+        assert!(el_ar_package.package().is_err()); // the model is dropped, so the package cannot be accessed anymore
+    }
+
+    #[test]
     fn element_rename() {
         let model = AutosarModel::new();
         model.create_file("test.arxml", AutosarVersion::Autosar_00050).unwrap();
@@ -3351,6 +3619,45 @@ mod test {
         // update with a different valid reference and verify that the reference can be used
         el_fibex_element_ref.set_reference_target(&el_ecu_instance2).unwrap();
         assert_eq!(el_fibex_element_ref.get_reference_target().unwrap(), el_ecu_instance2);
+
+        // define a REFERENCE-BASE and then set a relative reference via BASE
+        let el_reference_bases = el_ar_package.create_sub_element(ElementName::ReferenceBases).unwrap();
+        let el_reference_base = el_reference_bases
+            .create_sub_element(ElementName::ReferenceBase)
+            .unwrap();
+        el_reference_base
+            .create_sub_element(ElementName::ShortLabel)
+            .and_then(|short_label| short_label.set_character_data("default"))
+            .unwrap();
+        el_reference_base
+            .create_sub_element(ElementName::PackageRef)
+            .and_then(|package_ref| package_ref.set_reference_target(&el_ar_package))
+            .unwrap();
+        assert!(model.0.read().reference_bases.contains_key("default"));
+
+        el_fibex_element_ref
+            .set_relative_reference_target(&el_ecu_instance2, "default")
+            .unwrap();
+        assert_eq!(
+            el_fibex_element_ref
+                .attribute_value(AttributeName::Base)
+                .and_then(|cdata| cdata.string_value())
+                .unwrap(),
+            "default"
+        );
+        assert_eq!(
+            el_fibex_element_ref
+                .character_data()
+                .and_then(|cdata| cdata.string_value())
+                .unwrap(),
+            "EcuInstance2"
+        );
+        assert_eq!(el_fibex_element_ref.get_reference_target().unwrap(), el_ecu_instance2);
+        assert!(
+            model
+                .get_references_to("/Package/EcuInstance2")
+                .contains(&el_fibex_element_ref.downgrade())
+        );
 
         // set a valid reference to <CAN-TP-CONNECTION><IDENT>.
         // This is a complex case, as the correct DEST attribute must be looked up in the specification
@@ -4175,5 +4482,355 @@ mod test {
         for elem in ar_packages_elem.elements_dfs_with_max_depth(2) {
             assert!(elem.0 <= 2);
         }
+    }
+
+    #[test]
+    fn parse_reference_bases() {
+        // from issue #36
+        const FILEBUF: &[u8] = r#"<?xml version="1.0" encoding="utf-8"?>
+<AUTOSAR xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://autosar.org/schema/r4.0" xsi:schemaLocation="http://autosar.org/schema/r4.0 AUTOSAR_00048.xsd">
+  <AR-PACKAGES>
+    <AR-PACKAGE>
+      <SHORT-NAME>My</SHORT-NAME>
+      <AR-PACKAGES>
+        <AR-PACKAGE>
+          <SHORT-NAME>Lib</SHORT-NAME>
+          <AR-PACKAGES>
+            <AR-PACKAGE>
+              <SHORT-NAME>Hierarchy</SHORT-NAME>
+              <AR-PACKAGES>
+                <AR-PACKAGE>
+                  <SHORT-NAME>Units</SHORT-NAME>
+                  <ELEMENTS>
+                    <UNIT>
+                      <SHORT-NAME>MyUnit</SHORT-NAME>
+                      <FACTOR-SI-TO-UNIT>1</FACTOR-SI-TO-UNIT>
+                      <OFFSET-SI-TO-UNIT>0</OFFSET-SI-TO-UNIT>
+                    </UNIT>
+                  </ELEMENTS>
+                </AR-PACKAGE>
+              </AR-PACKAGES>
+            </AR-PACKAGE>
+          </AR-PACKAGES>
+        </AR-PACKAGE>
+        <AR-PACKAGE>
+          <SHORT-NAME>SWC</SHORT-NAME>
+          <REFERENCE-BASES>
+            <REFERENCE-BASE>
+              <SHORT-LABEL>Units</SHORT-LABEL>
+              <PACKAGE-REF DEST="AR-PACKAGE">/My/Lib/Hierarchy/Units</PACKAGE-REF>
+            </REFERENCE-BASE>
+          </REFERENCE-BASES>
+          <AR-PACKAGES>
+            <AR-PACKAGE>
+              <SHORT-NAME>ApplicationDataTypes</SHORT-NAME>
+              <ELEMENTS>
+                <APPLICATION-PRIMITIVE-DATA-TYPE>
+                  <SHORT-NAME>MyDataType</SHORT-NAME>
+                  <CATEGORY>VALUE</CATEGORY>
+                  <SW-DATA-DEF-PROPS>
+                    <SW-DATA-DEF-PROPS-VARIANTS>
+                      <SW-DATA-DEF-PROPS-CONDITIONAL>
+                        <SW-CALIBRATION-ACCESS>NOT-ACCESSIBLE</SW-CALIBRATION-ACCESS>
+                        <UNIT-REF DEST="UNIT" BASE="Units">MyUnit</UNIT-REF>
+                      </SW-DATA-DEF-PROPS-CONDITIONAL>
+                    </SW-DATA-DEF-PROPS-VARIANTS>
+                  </SW-DATA-DEF-PROPS>
+                </APPLICATION-PRIMITIVE-DATA-TYPE>
+              </ELEMENTS>
+            </AR-PACKAGE>
+          </AR-PACKAGES>
+        </AR-PACKAGE>
+      </AR-PACKAGES>
+    </AR-PACKAGE>
+  </AR-PACKAGES>
+</AUTOSAR>"#.as_bytes();
+        let model = AutosarModel::new();
+        let (_, _) = model.load_buffer(FILEBUF, "test1", true).unwrap();
+
+        let unit_elem = model.get_element_by_path("/My/Lib/Hierarchy/Units/MyUnit").unwrap();
+        assert_eq!(unit_elem.element_name(), ElementName::Unit);
+
+        // verify that the reference base has been correctly parsed and cached
+        assert_eq!(model.0.read().reference_bases.len(), 1);
+        let locked_model = model.0.read();
+        let (rb, rb_infos) = &locked_model.reference_bases.iter().next().unwrap();
+        assert_eq!(*rb, "Units");
+        assert_eq!(rb_infos.len(), 1);
+        assert_eq!(rb_infos[0].package_ref, "/My/Lib/Hierarchy/Units");
+        drop(locked_model);
+
+        // verify that we're correctly tracking incoming references to the unit element from the reference base
+        let refs_to_unit = model.get_references_to(&unit_elem.path().unwrap());
+        assert_eq!(refs_to_unit.len(), 1);
+        let reference_elem = refs_to_unit[0].upgrade().unwrap();
+        assert_eq!(reference_elem.element_name(), ElementName::UnitRef);
+        assert!(reference_elem.attribute_value(AttributeName::Base).is_some());
+
+        // verify that we can navigate from the reference element to the target unit element
+        let target = reference_elem.get_reference_target().unwrap();
+        assert_eq!(target, unit_elem);
+    }
+
+    #[test]
+    fn modify_relative_ref() {
+        const FILEBUF: &[u8] = r#"<?xml version="1.0" encoding="utf-8"?>
+<AUTOSAR xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://autosar.org/schema/r4.0" xsi:schemaLocation="http://autosar.org/schema/r4.0 AUTOSAR_00048.xsd">
+  <AR-PACKAGES>
+    <AR-PACKAGE>
+      <SHORT-NAME>First</SHORT-NAME>
+      <AR-PACKAGES>
+        <AR-PACKAGE>
+          <SHORT-NAME>Second</SHORT-NAME>
+          <ELEMENTS>
+            <ECU-INSTANCE>
+              <SHORT-NAME>Ecu</SHORT-NAME>
+            </ECU-INSTANCE>
+          </ELEMENTS>
+        </AR-PACKAGE>
+      </AR-PACKAGES>
+    </AR-PACKAGE>
+    <AR-PACKAGE>
+      <SHORT-NAME>Ref</SHORT-NAME>
+      <REFERENCE-BASES>
+        <REFERENCE-BASE>
+          <SHORT-LABEL>First</SHORT-LABEL>
+          <PACKAGE-REF DEST="AR-PACKAGE">/First</PACKAGE-REF>
+        </REFERENCE-BASE>
+        <REFERENCE-BASE>
+          <SHORT-LABEL>Second</SHORT-LABEL>
+          <PACKAGE-REF DEST="AR-PACKAGE">/First/Second</PACKAGE-REF>
+        </REFERENCE-BASE>
+      </REFERENCE-BASES>
+      <ELEMENTS>
+        <SYSTEM>
+          <SHORT-NAME>System</SHORT-NAME>
+          <FIBEX-ELEMENTS>
+            <FIBEX-ELEMENT-REF-CONDITIONAL>
+              <FIBEX-ELEMENT-REF DEST="ECU-INSTANCE" BASE="First">Second/Ecu</FIBEX-ELEMENT-REF>
+            </FIBEX-ELEMENT-REF-CONDITIONAL>
+          </FIBEX-ELEMENTS>
+        </SYSTEM>
+      </ELEMENTS>
+    </AR-PACKAGE>
+  </AR-PACKAGES>
+</AUTOSAR>"#.as_bytes();
+        let model = AutosarModel::new();
+        let (_, _) = model.load_buffer(FILEBUF, "test1", true).unwrap();
+
+        let ref_elem = model
+            .get_element_by_path("/Ref/System")
+            .unwrap()
+            .get_sub_element(ElementName::FibexElements)
+            .unwrap()
+            .get_sub_element(ElementName::FibexElementRefConditional)
+            .unwrap()
+            .get_sub_element(ElementName::FibexElementRef)
+            .unwrap();
+        let ecu_elem = ref_elem.get_reference_target().unwrap();
+        assert_eq!(ecu_elem.element_name(), ElementName::EcuInstance);
+        assert_eq!(model.get_references_to(&ecu_elem.path().unwrap()).len(), 1);
+
+        ref_elem.set_relative_reference_target(&ecu_elem, "Second").unwrap();
+        assert_eq!(ref_elem.character_data().unwrap().string_value().unwrap(), "Ecu");
+        assert_eq!(model.get_references_to(&ecu_elem.path().unwrap()).len(), 1);
+    }
+
+    #[test]
+    fn create_modify_delete_ref_bases() {
+        let model = AutosarModel::new();
+        model.create_file("test", AutosarVersion::LATEST).unwrap();
+        let el_autosar = model.root_element();
+        let el_ar_packages = el_autosar.create_sub_element(ElementName::ArPackages).unwrap();
+        let el_ar_package = el_ar_packages
+            .create_named_sub_element(ElementName::ArPackage, "Pkg")
+            .unwrap();
+        let el_ar_package2 = el_ar_packages
+            .create_named_sub_element(ElementName::ArPackage, "Pkg2")
+            .unwrap();
+        let el_reference_bases = el_ar_package.create_sub_element(ElementName::ReferenceBases).unwrap();
+        let el_reference_base = el_reference_bases
+            .create_sub_element(ElementName::ReferenceBase)
+            .unwrap();
+        // no cached reference base, because label and packageref are missing
+        assert_eq!(model.0.read().reference_bases.len(), 0);
+        let el_short_label = el_reference_base.create_sub_element(ElementName::ShortLabel).unwrap();
+        el_short_label.set_character_data("Units").unwrap();
+        // no cached reference base, because packageref is missing
+        assert_eq!(model.0.read().reference_bases.len(), 0);
+        let el_package_ref = el_reference_base.create_sub_element(ElementName::PackageRef).unwrap();
+        el_package_ref.set_reference_target(&el_ar_package2).unwrap();
+        // cached reference base should be created now
+        assert_eq!(model.0.read().reference_bases.len(), 1);
+
+        el_short_label.set_character_data("Modified").unwrap();
+        // cached reference base should be updated with the new label
+        let locked_model = model.0.read();
+        let (rb, rb_infos) = &locked_model.reference_bases.iter().next().unwrap();
+        assert_eq!(*rb, "Modified");
+        assert_eq!(rb_infos[0].package_ref, "/Pkg2");
+        assert_eq!(rb_infos.len(), 1);
+        drop(locked_model);
+
+        el_package_ref.set_reference_target(&el_ar_package).unwrap();
+        // cached reference base should be updated with the new package ref
+        let locked_model = model.0.read();
+        let (rb, rb_infos) = &locked_model.reference_bases.iter().next().unwrap();
+        assert_eq!(*rb, "Modified");
+        assert_eq!(rb_infos[0].package_ref, "/Pkg");
+        drop(locked_model);
+
+        el_reference_base.remove_sub_element(el_package_ref).unwrap();
+        // cached reference base should be removed again
+        assert_eq!(model.0.read().reference_bases.len(), 0);
+        // create it again
+        let el_package_ref = el_reference_base.create_sub_element(ElementName::PackageRef).unwrap();
+        el_package_ref.set_reference_target(&el_ar_package2).unwrap();
+        assert_eq!(model.0.read().reference_bases.len(), 1);
+        // remove the SHORT-LABEL
+        el_reference_base.remove_sub_element(el_short_label).unwrap();
+        // cached reference base should be removed again, because the label is missing
+        assert_eq!(model.0.read().reference_bases.len(), 0);
+        let el_short_label = el_reference_base.create_sub_element(ElementName::ShortLabel).unwrap();
+        el_short_label.set_character_data("Units").unwrap();
+        // cached reference base should be created again
+        assert_eq!(model.0.read().reference_bases.len(), 1);
+
+        el_reference_bases.remove_sub_element(el_reference_base).unwrap();
+        // cached reference base should be removed again, because the reference base itself is removed
+        assert_eq!(model.0.read().reference_bases.len(), 0);
+    }
+
+    #[test]
+    fn rename_reference_base() {
+        let model = AutosarModel::new();
+        model.create_file("test", AutosarVersion::LATEST).unwrap();
+
+        let el_ar_packages = model
+            .root_element()
+            .create_sub_element(ElementName::ArPackages)
+            .unwrap();
+        let owner1 = el_ar_packages
+            .create_named_sub_element(ElementName::ArPackage, "Owner1")
+            .unwrap();
+        let owner2 = el_ar_packages
+            .create_named_sub_element(ElementName::ArPackage, "Owner2")
+            .unwrap();
+        let target1 = el_ar_packages
+            .create_named_sub_element(ElementName::ArPackage, "Target1")
+            .unwrap();
+        let target2 = el_ar_packages
+            .create_named_sub_element(ElementName::ArPackage, "Target2")
+            .unwrap();
+
+        let short_label_1 = owner1
+            .create_sub_element(ElementName::ReferenceBases)
+            .and_then(|e| e.create_sub_element(ElementName::ReferenceBase))
+            .and_then(|e| {
+                e.create_sub_element(ElementName::ShortLabel)
+                    .and_then(|l| l.set_character_data("Shared").map(|_| l))
+            })
+            .unwrap();
+        let owner1_reference_base = owner1
+            .get_sub_element(ElementName::ReferenceBases)
+            .and_then(|e| e.get_sub_element(ElementName::ReferenceBase))
+            .unwrap();
+        owner1_reference_base
+            .create_sub_element(ElementName::PackageRef)
+            .and_then(|p| p.set_reference_target(&target1))
+            .unwrap();
+
+        owner2
+            .create_sub_element(ElementName::ReferenceBases)
+            .and_then(|e| e.create_sub_element(ElementName::ReferenceBase))
+            .and_then(|e| {
+                e.create_sub_element(ElementName::ShortLabel)
+                    .and_then(|l| l.set_character_data("Shared").map(|_| l))
+            })
+            .unwrap();
+        let owner2_reference_base = owner2
+            .get_sub_element(ElementName::ReferenceBases)
+            .and_then(|e| e.get_sub_element(ElementName::ReferenceBase))
+            .unwrap();
+        owner2_reference_base
+            .create_sub_element(ElementName::PackageRef)
+            .and_then(|p| p.set_reference_target(&target2))
+            .unwrap();
+
+        assert_eq!(model.0.read().reference_bases.get("Shared").unwrap().len(), 2);
+
+        short_label_1.set_character_data("Renamed").unwrap();
+
+        let data = model.0.read();
+        let shared_entries = data.reference_bases.get("Shared").unwrap();
+        assert_eq!(shared_entries.len(), 1);
+        assert_eq!(shared_entries[0].owner_package_path, "/Owner2");
+        assert_eq!(shared_entries[0].package_ref, "/Target2");
+
+        let renamed_entries = data.reference_bases.get("Renamed").unwrap();
+        assert_eq!(renamed_entries.len(), 1);
+        assert_eq!(renamed_entries[0].owner_package_path, "/Owner1");
+        assert_eq!(renamed_entries[0].package_ref, "/Target1");
+    }
+
+    #[test]
+    fn changing_base_attribute() {
+        let model = AutosarModel::new();
+        model.create_file("test", AutosarVersion::LATEST).unwrap();
+
+        let el_ar_packages = model
+            .root_element()
+            .create_sub_element(ElementName::ArPackages)
+            .unwrap();
+        let base_a = el_ar_packages
+            .create_named_sub_element(ElementName::ArPackage, "BaseA")
+            .unwrap();
+        let base_b = el_ar_packages
+            .create_named_sub_element(ElementName::ArPackage, "BaseB")
+            .unwrap();
+        let ref_pkg = el_ar_packages
+            .create_named_sub_element(ElementName::ArPackage, "RefPkg")
+            .unwrap();
+
+        let ecu_a = base_a
+            .create_sub_element(ElementName::Elements)
+            .and_then(|e| e.create_named_sub_element(ElementName::EcuInstance, "Ecu"))
+            .unwrap();
+        let _ecu_b = base_b
+            .create_sub_element(ElementName::Elements)
+            .and_then(|e| e.create_named_sub_element(ElementName::EcuInstance, "Ecu"))
+            .unwrap();
+
+        let ref_bases = ref_pkg.create_sub_element(ElementName::ReferenceBases).unwrap();
+        let rb_a = ref_bases.create_sub_element(ElementName::ReferenceBase).unwrap();
+        rb_a.create_sub_element(ElementName::ShortLabel)
+            .and_then(|e| e.set_character_data("A"))
+            .unwrap();
+        rb_a.create_sub_element(ElementName::PackageRef)
+            .and_then(|e| e.set_reference_target(&base_a))
+            .unwrap();
+
+        let rb_b = ref_bases.create_sub_element(ElementName::ReferenceBase).unwrap();
+        rb_b.create_sub_element(ElementName::ShortLabel)
+            .and_then(|e| e.set_character_data("B"))
+            .unwrap();
+        rb_b.create_sub_element(ElementName::PackageRef)
+            .and_then(|e| e.set_reference_target(&base_b))
+            .unwrap();
+
+        let ref_elem = ref_pkg
+            .create_sub_element(ElementName::Elements)
+            .and_then(|e| e.create_named_sub_element(ElementName::System, "Sys"))
+            .and_then(|e| e.create_sub_element(ElementName::FibexElements))
+            .and_then(|e| e.create_sub_element(ElementName::FibexElementRefConditional))
+            .and_then(|e| e.create_sub_element(ElementName::FibexElementRef))
+            .unwrap();
+        ref_elem.set_relative_reference_target(&ecu_a, "A").unwrap();
+
+        ref_elem.set_attribute_string(AttributeName::Base, "B").unwrap();
+
+        let origins = model.0.read().relative_reference_origins.get("Ecu").unwrap().clone();
+        let ref_origin = ref_elem.downgrade();
+        assert!(origins.iter().any(|(elem, base)| *elem == ref_origin && base == "B"));
     }
 }

--- a/autosar-data/src/elementraw.rs
+++ b/autosar-data/src/elementraw.rs
@@ -519,7 +519,10 @@ impl ElementRaw {
             if sub_elem.is_reference()
                 && let Some(CharacterData::String(reference)) = sub_elem.character_data()
             {
-                model.add_reference_origin(&reference, sub_elem.downgrade());
+                let base = sub_elem
+                    .attribute_value(AttributeName::Base)
+                    .and_then(|cdata| cdata.string_value());
+                model.add_reference_origin(&reference, base.as_deref(), sub_elem.downgrade());
             }
         }
 
@@ -913,7 +916,10 @@ impl ElementRaw {
         }
         // delete all reference origin info for elements under move_element
         for (path, elem) in &original_refs {
-            model_src.remove_reference_origin(path, elem.downgrade());
+            let base = elem
+                .attribute_value(AttributeName::Base)
+                .and_then(|cdata| cdata.string_value());
+            model_src.remove_reference_origin(path, base.as_deref(), elem.downgrade());
         }
 
         // set the parent of the new element to the current element
@@ -943,7 +949,10 @@ impl ElementRaw {
                     refstr = format!("{dest_path}{suffix}");
                     ref_element.0.write().set_character_data(refstr.clone(), version)?;
                 }
-                model.add_reference_origin(&refstr, ref_element.downgrade());
+                let base = ref_element
+                    .attribute_value(AttributeName::Base)
+                    .and_then(|cdata| cdata.string_value());
+                model.add_reference_origin(&refstr, base.as_deref(), ref_element.downgrade());
             }
         }
 
@@ -1100,6 +1109,14 @@ impl ElementRaw {
         if self.elemtype.is_named() && sub_element_locked.elemname == ElementName::ShortName {
             // may not remove the SHORT-NAME, because that would leave the data in an invalid state
             return Err(AutosarDataError::ShortNameRemovalForbidden);
+        } else if self.elemname == ElementName::ReferenceBases
+            && sub_element_locked.elemname == ElementName::ReferenceBase
+        {
+            // removing a whole reference base
+            self.remove_reference_base(model, &sub_element_locked);
+        } else if self.elemname == ElementName::ReferenceBase {
+            // removing data from a reference base, making it invalid
+            self.remove_incomplete_reference_base(model, &sub_element_locked);
         }
         sub_element_locked.remove_internal(sub_element.downgrade(), model, path);
         self.content.remove(pos);
@@ -1123,7 +1140,10 @@ impl ElementRaw {
             && let Some(CharacterData::String(reference)) = self.character_data()
         {
             // remove the references-reference (ugh. terminology???)
-            model.remove_reference_origin(&reference, self_weak);
+            let base = self
+                .attribute_value(AttributeName::Base)
+                .and_then(|cdata| cdata.string_value());
+            model.remove_reference_origin(&reference, base.as_deref(), self_weak);
         }
         for item in &self.content {
             if let ElementContent::Element(sub_element) = item {
@@ -1314,6 +1334,62 @@ impl ElementRaw {
             }
             ContentMode::Characters | ContentMode::Mixed => {}
         }
+    }
+
+    fn remove_reference_base(&mut self, model: &AutosarModel, sub_element_locked: &ElementRaw) -> Option<()> {
+        // here self is a REFERENCE-BASES element and sub_element_locked is the REFERENCE-BASE element that is being removed from it.
+        let base_label = sub_element_locked.content.iter().find_map(|item| {
+            if let ElementContent::Element(elem) = item
+                && elem.element_name() == ElementName::ShortLabel
+            {
+                elem.character_data()?.string_value()
+            } else {
+                None
+            }
+        })?;
+        // the parent of REFERENCE-BASES is an AR-PACKAGE, so the owner package path can be obtained from it
+        let owner_package_path = if let ElementOrModel::Element(weak_parent) = &self.parent {
+            weak_parent.upgrade()?.path().ok()?
+        } else {
+            return None;
+        };
+        model.remove_reference_base(&base_label, &owner_package_path);
+
+        Some(())
+    }
+
+    fn remove_incomplete_reference_base(
+        &mut self,
+        model: &AutosarModel,
+        sub_element_locked: &parking_lot::lock_api::RwLockWriteGuard<'_, parking_lot::RawRwLock, ElementRaw>,
+    ) -> Option<()> {
+        // self is a a REFERENCE-BASE element
+        let base_label = if sub_element_locked.elemname == ElementName::ShortLabel {
+            sub_element_locked.character_data()?.string_value()?
+        } else if sub_element_locked.elemname == ElementName::PackageRef {
+            self.content
+                .iter()
+                .find_map(|item| {
+                    if let ElementContent::Element(elem) = item
+                        && elem.element_name() == ElementName::ShortLabel
+                    {
+                        Some(elem)
+                    } else {
+                        None
+                    }
+                })?
+                .character_data()?
+                .string_value()?
+        } else {
+            return None;
+        };
+        let ElementOrModel::Element(weak_parent) = &self.parent else {
+            return None;
+        };
+        let owner_package_path = weak_parent.upgrade()?.package().ok()??.path().ok()?;
+        model.remove_reference_base(&base_label, &owner_package_path);
+
+        Some(())
     }
 
     pub(crate) fn wrap(self) -> Element {

--- a/autosar-data/src/lib.rs
+++ b/autosar-data/src/lib.rs
@@ -110,6 +110,13 @@ pub use autosar_data_specification::EnumItem;
 
 type FxIndexMap<K, V> = IndexMap<K, V, FxBuildHasher>;
 
+#[derive(Debug, Clone)]
+pub(crate) struct ReferenceBaseInfo {
+    pub(crate) owner_package_path: String,
+    pub(crate) package_ref: String,
+    pub(crate) package_ref_base: Option<String>,
+}
+
 /// `AutosarModel` is the top level data type in the autosar-data crate.
 ///
 /// An instance of `AutosarModel` is required for all other operations.
@@ -134,8 +141,12 @@ pub(crate) struct AutosarModelRaw {
     files: Vec<ArxmlFile>,
     /// `identifiables` is a `HashMap` of all named elements, needed to resolve references without doing a full search.
     identifiables: FxIndexMap<String, WeakElement>,
-    /// `reference_origins` is a `HashMap` of all referencing elements. This is needed to efficiently fix up the references when a referenced element is renamed.
+    /// `reference_origins` is a `HashMap` of all referencing elements.
     reference_origins: FxHashMap<String, Vec<WeakElement>>,
+    /// `relative_reference_origins` is a `HashMap` of all referencing elements with relative paths.
+    relative_reference_origins: FxHashMap<String, Vec<(WeakElement, String)>>, // Relative path -> [(referencing element, base label)]*
+    /// `reference_bases` stores all REFERENCE-BASE declarations indexed by short label.
+    reference_bases: FxHashMap<String, Vec<ReferenceBaseInfo>>,
 }
 
 /// The error type `AutosarDataError` wraps all errors that can be generated anywhere in the crate
@@ -294,6 +305,10 @@ pub enum AutosarDataError {
     /// The reference is invalid
     #[error("The reference is not valid")]
     InvalidReference,
+
+    /// The reference base of a relative reference is not valid (not a valid label, or not a prefix of the target element)
+    #[error("The reference base is not valid")]
+    InvalidReferenceBase,
 
     /// An element could not be renamed, since this item name is already used by a different element
     #[error("Duplicate item name {} in {}", .item_name, .element)]

--- a/autosar-data/src/parser.rs
+++ b/autosar-data/src/parser.rs
@@ -12,7 +12,8 @@ use thiserror::Error;
 
 use crate::lexer::{ArxmlEvent, ArxmlLexer};
 use crate::{
-    Attribute, AutosarDataError, CharacterData, Element, ElementContent, ElementOrModel, ElementRaw, WeakElement,
+    Attribute, AutosarDataError, CharacterData, Element, ElementContent, ElementOrModel, ElementRaw, ReferenceBaseInfo,
+    WeakElement,
 };
 
 #[derive(Debug, Error, PartialEq)]
@@ -256,7 +257,8 @@ pub(crate) struct ArxmlParser<'a> {
     strict: bool,
     version_compatibility: u32,
     pub(crate) identifiables: Vec<(String, WeakElement)>,
-    pub(crate) references: Vec<(String, WeakElement)>,
+    pub(crate) references: Vec<(String, WeakElement, Option<String>)>,
+    pub(crate) reference_bases: Vec<(String, ReferenceBaseInfo)>,
     pub(crate) warnings: Vec<AutosarDataError>,
     standalone: Option<bool>,
 }
@@ -273,6 +275,7 @@ impl<'a> ArxmlParser<'a> {
             version_compatibility: u32::MAX,
             identifiables: Vec::new(),
             references: Vec::new(),
+            reference_bases: Vec::new(),
             warnings: Vec::new(),
             standalone: None,
         }
@@ -528,7 +531,11 @@ impl<'a> ArxmlParser<'a> {
                         if element.elemtype.is_ref()
                             && let CharacterData::String(refpath) = &value
                         {
-                            self.references.push((refpath.to_owned(), wrapped_element.downgrade()));
+                            let base = element
+                                .attribute_value(AttributeName::Base)
+                                .and_then(|cdata| cdata.string_value());
+                            self.references
+                                .push((refpath.to_owned(), wrapped_element.downgrade(), base));
                         }
                         element.content.push(ElementContent::CharacterData(value));
                     } else {
@@ -557,6 +564,39 @@ impl<'a> ArxmlParser<'a> {
                 element: element.elemname,
                 sub_element: ElementName::ShortName,
             })?;
+        }
+
+        if element.elemname == ElementName::ReferenceBase {
+            let mut short_label = None;
+            let mut package_ref = None;
+            let mut package_ref_base = None;
+
+            for item in &element.content {
+                if let ElementContent::Element(sub_elem) = item {
+                    let sub_locked = sub_elem.0.read();
+                    if sub_locked.elemname == ElementName::ShortLabel {
+                        short_label = sub_locked.character_data().and_then(|cdata| cdata.string_value());
+                    } else if sub_locked.elemname == ElementName::PackageRef {
+                        package_ref = sub_locked.character_data().and_then(|cdata| cdata.string_value());
+                        package_ref_base = sub_locked
+                            .attribute_value(AttributeName::Base)
+                            .and_then(|cdata| cdata.string_value());
+                    }
+                }
+            }
+
+            if let (Some(short_label), Some(package_ref)) = (short_label, package_ref)
+                && !path.is_empty()
+            {
+                self.reference_bases.push((
+                    short_label,
+                    ReferenceBaseInfo {
+                        owner_package_path: path.as_ref().to_string(),
+                        package_ref,
+                        package_ref_base,
+                    },
+                ));
+            }
         }
 
         Ok(wrapped_element.clone())
@@ -1534,6 +1574,58 @@ mod test {
         let mut parser = ArxmlParser::new(PathBuf::from("test_buffer.arxml"), PARSER_TEST_DATA.as_bytes(), true);
         let result = parser.parse_arxml();
         assert!(result.is_ok());
+    }
+
+    const PARSER_TEST_RELATIVE_REFERENCE_BASE: &str = r#"<?xml version="1.0" encoding="utf-8"?>
+    <AUTOSAR xsi:schemaLocation="http://autosar.org/schema/r4.0 AUTOSAR_00050.xsd" xmlns="http://autosar.org/schema/r4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <AR-PACKAGES>
+            <AR-PACKAGE>
+                <SHORT-NAME>base</SHORT-NAME>
+                <REFERENCE-BASES>
+                    <REFERENCE-BASE>
+                        <SHORT-LABEL>default</SHORT-LABEL>
+                        <PACKAGE-REF DEST="AR-PACKAGE">/base</PACKAGE-REF>
+                    </REFERENCE-BASE>
+                </REFERENCE-BASES>
+                <ELEMENTS>
+                    <SYSTEM>
+                        <SHORT-NAME>System</SHORT-NAME>
+                        <FIBEX-ELEMENTS>
+                            <FIBEX-ELEMENT-REF-CONDITIONAL>
+                                <FIBEX-ELEMENT-REF DEST="I-SIGNAL-I-PDU" BASE="default">Pdu</FIBEX-ELEMENT-REF>
+                            </FIBEX-ELEMENT-REF-CONDITIONAL>
+                        </FIBEX-ELEMENTS>
+                    </SYSTEM>
+                    <I-SIGNAL-I-PDU>
+                        <SHORT-NAME>Pdu</SHORT-NAME>
+                    </I-SIGNAL-I-PDU>
+                </ELEMENTS>
+            </AR-PACKAGE>
+        </AR-PACKAGES>
+    </AUTOSAR>
+    "#;
+
+    #[test]
+    fn parse_reference_base_and_relative_reference() {
+        let mut parser = ArxmlParser::new(
+            PathBuf::from("test_buffer.arxml"),
+            PARSER_TEST_RELATIVE_REFERENCE_BASE.as_bytes(),
+            true,
+        );
+
+        let result = parser.parse_arxml();
+        assert!(result.is_ok());
+
+        assert_eq!(parser.reference_bases.len(), 1);
+        let (base_label, base_info) = &parser.reference_bases[0];
+        assert_eq!(base_label, "default");
+        assert_eq!(base_info.package_ref, "/base");
+        assert_eq!(base_info.owner_package_path, "/base");
+        assert_eq!(base_info.package_ref_base, None);
+
+        assert_eq!(parser.references.len(), 2);
+        assert!(parser.references.iter().any(|(refpath, _, _)| refpath == "/base"));
+        assert!(parser.references.iter().any(|(refpath, _, _)| refpath == "Pdu"));
     }
 
     const EMPTY_CHARACTER_DATA: &str = r#"<?xml version="1.0" encoding="utf-8"?>


### PR DESCRIPTION
References can now use the BASE attribute to refer to any in-scope reference base. With a reference base, the reference itself only provides a relative path.

New API: ` Element::set_relative_reference_target()` sets a relative reference rather than an absolute reference

Fixes issue #36